### PR TITLE
Added fix to show page for extended images results. Changed explanato…

### DIFF
--- a/app/controllers/websites_controller.rb
+++ b/app/controllers/websites_controller.rb
@@ -158,7 +158,7 @@ class WebsitesController < ApplicationController
     CarbonApiJob.perform_later(url, @version)
     # fonts_and_backgrounds_scraping(html_doc)
     # image_scraping(html_doc)
-    sleep 10
+    sleep 20
 
     # if carbon_infos.nil?
       # @version.update(all_images_size: @all_images_size, background_color: background_color, font_families: font_families )

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -33,9 +33,8 @@
   <div class="green-container-home black-background" data-dark-mode-target="green">
     <div class="spacer"></div>
     <div class="container text-center text-light">
-      <h3>WORK IN PROGRESS!</h3>
-      <p>One degree design is currently not able to process all websites but here are some examples that work well: <i>marmiton.org, smith.edu, food.com, lewagon.com.</i></p>
-      <p>Please note that the scraping time can sometimes reach up to 30 seconds. Have fun!</p>
+      <h1>Analysis will take 20 seconds or longer to complete</h1>
+      <p>We're currently not able to analyze all websites. Here are a few examples that work well: <i>lewagon.com, marmiton.org, pollutingsite.com.</i></p>
     </div>
   </div>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,13 +1,9 @@
 <div class="footer sticky-bottom black-background" data-dark-mode-target="footer">
   <div class="footer-links">
     <a href="https://github.com/brendan-oconnell/one-degree-design" target="_blank"><i class="fab fa-github dark-mode-text"></i></a>
-    <a href="#"><i class="fab fa-instagram dark-mode-text"></i></a>
-    <a href="#"><i class="fab fa-facebook dark-mode-text"></i></a>
-    <a href="#"><i class="fab fa-twitter dark-mode-text"></i></a>
-    <a href="#"><i class="fab fa-linkedin dark-mode-text"></i></a>
   </div>
   <div class="footer-copyright dark-mode-text">
-    <p class="dark-mode-text">This project uses data from <a href="https://api.websitecarbon.com/" target="_blank" class="dark-mode-text">Website Carbon API</a>
+    <p class="dark-mode-text"><a href="https://api.websitecarbon.com/" target="_blank" class="dark-mode-text">This project uses data from the Website Carbon API</a>
     </p>
   </div>
 </div>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -4,7 +4,7 @@
       <% if @version.co2_renewable %>
         <p> How's your carbon footprint?</p>
       <% else %>
-        <p>Looks like your website is a tough job for the API, please refresh in a few seconds to get the API results</p>
+        <p>It's taking longer than expected to get your results - for larger or complex websites, it can take up to 30 seconds or more! Try refreshing this page in a few seconds.</p>
       <% end %>
   </div>
 
@@ -23,14 +23,14 @@
         </div>
         <div>
           <% if @version.cleaner_than.nil? %>
-            <p>CO2 consumption unknown yet</p>
+            <p>CO2 consumption unknown</p>
           <% elsif @version.cleaner_than > 0.5 %>
             <p>Cleaner than <strong class="green"><%= (@version.cleaner_than * 100).to_i %>% of sites tested!</strong></p>
           <% else %>
             <p>Dirtier than <strong class="red"><%= 100 - (@version.cleaner_than * 100).to_i %>% of sites tested.</strong></p>
           <% end %>
           <% if @version.green_hosting.nil? %>
-            <p>Green hosting unkown yet</p>
+            <p>Green hosting unkown</p>
           <% elsif @version.green_hosting %>
             <p>Your site is using green hosting!</p>
           <% else %>
@@ -47,7 +47,7 @@
             <p><strong><%= (@version.bytes/1000000).round(2) %> megabytes</strong></p>
             <p>The size of your site</p>
           <% else %>
-            <p>Size unknown yet</p>
+            <p>Size unknown</p>
           <% end %>
         </div>
       </div>
@@ -92,7 +92,7 @@
           Fonts
           <div class="card-category">
             <% if @version.font_families.nil? %>
-              <p><strong>The fonts could not be scraped</strong></p>
+              <p><strong>We couldn't find the fonts for your site.</strong></p>
               <br>
               <p>Fonts like <strong>Open Sans, Times New Roman, Georgia, Arial or Helvetica</strong>, to name a few, don't add any extra weight to your site. Hopefully you are using those!</p>
 
@@ -119,7 +119,7 @@
           Background Colors
           <div class="card-category">
             <% if @version.background_color.nil? %>
-              <p>Your background colors could not be scraped</p>
+              <p>We couldn't find the background colors for your site.</p>
             <% else %>
               <p>Most-used background colors on your site:</p>
               <div class="background-colors">
@@ -158,60 +158,59 @@
       <div class="analysis-banner">
         <h1>Reducing image file size</h1>
       </div>
+      <% if @version.photos.nil? || @version.photos == [] %>
+          <h1>Looks like it's taking longer than expected to analyze the images from your site. Try refreshing this page in a few seconds.</h1>
+      <% else %>
+        <div class="row analysis-row" style="padding-bottom: 8px">
+          <div class="analysis-card col-4">
+              <% if @version.photos && @version.photos %>
+                <img src="<%= eval(@version.photos[0])[:url] %>" alt="">
+              <% else %>
+                <img src="https://picsum.photos/500/500" alt="">
+              <% end %>
+          </div>
 
-      <div class="row analysis-row" style="padding-bottom: 8px">
-        <div class="analysis-card col-4">
-            <% if @version.photos && @version.photos %>
-              <img src="<%= eval(@version.photos[0])[:url] %>" alt="">
-            <% else %>
-              <img src="https://picsum.photos/500/500" alt="">
-            <% end %>
+          <div class="tip-card pe-0 col-8">
+            <div class="results">
+              <div class="current">
+                <h3>CURRENT SIZE</h3>
+                <p><%= eval(@version.photos[0])[:dimensions][0] %> x <%= eval(@version.photos[0])[:dimensions][1] %> px</p>
+              </div>
+              <div class="reduced">
+            <% if eval(@version.photos[0])[:dimensions][0] < 100 %>
+                <h3>REDUCED </h3>
+                <p><%= eval(@version.photos[0])[:dimensions][0] %> x <%= eval(@version.photos[0])[:dimensions][1] %> px</p>
+              </div>
+              <div class="smaller">
+                <h3>SMALLER</h3>
+                <p><strong>0%</strong></p>
+              </div>
+            </div>
+            <div class="solutions" data-dark-mode-target="image">
+              <h2><i class="fa-solid fa-lightbulb" data-dark-mode-target="bulb"></i> Great job!</h2>
+              <%# <p>This image is  <strong><%= eval(@version.photos[0])[:dimensions][0] x <%= eval(@version.photos[0])[:dimensions][1] pixels</strong></p>%>
+              <p>Your images are already really small! Nice work!</p>
+              <p class="mb-0"><a href="">Learn More</a></p>
+            </div>
+            <% else  %>
+              <h3>REDUCED</h3>
+              <p><%= eval(@version.photos[0])[:dimensions][0]/10 %> x <%= eval(@version.photos[0])[:dimensions][1]/10 %> px</p>
+            </div>
+              <div class="smaller">
+                <h3>SMALLER</h3>
+                <p><strong>90%</strong></p>
+              </div>
+            </div>
+            <div class="solutions" data-dark-mode-target="image">
+                    <h2><i class="fa-solid fa-lightbulb" data-dark-mode-target="bulb"></i> Use fewer pixels</h2>
+                    <%# <p>This image is  <strong><%= eval(@version.photos[0])[:dimensions][0] x <%= eval(@version.photos[0])[:dimensions][1] pixels</strong></p>%>
+                    <p>Are your image files larger than their container? Generally speaking, image pixel sizes should be no larger than their div container. For example, if your div is 500 x 400px but your image is 3000 x 2000 px, your user will never see the extra pixels, and your large file will increase your carbon footprint.</p>
+                    <p class="mb-0"><a href="">Learn More</a></p>
+            </div>
+          <% end %>
+          </div>
         </div>
-
-        <div class="tip-card pe-0 col-8">
-          <div class="results">
-            <div class="current">
-              <h3>CURRENT SIZE</h3>
-              <p><%= eval(@version.photos[0])[:dimensions][0] %> x <%= eval(@version.photos[0])[:dimensions][1] %> px</p>
-            </div>
-            <div class="reduced">
-          <% if eval(@version.photos[0])[:dimensions][0] < 100 %>
-              <h3>REDUCED </h3>
-              <p><%= eval(@version.photos[0])[:dimensions][0] %> x <%= eval(@version.photos[0])[:dimensions][1] %> px</p>
-            </div>
-            <div class="smaller">
-              <h3>SMALLER</h3>
-              <p><strong>0%</strong></p>
-            </div>
-          </div>
-          <div class="solutions" data-dark-mode-target="image">
-            <h2><i class="fa-solid fa-lightbulb" data-dark-mode-target="bulb"></i> Great job!</h2>
-            <%# <p>This image is  <strong><%= eval(@version.photos[0])[:dimensions][0] x <%= eval(@version.photos[0])[:dimensions][1] pixels</strong></p>%>
-            <p>Can't get much smaller than that, we have nothing more to teach you on image sizes young padawan, congrats!</p>
-            <p class="mb-0"><a href="">Learn More</a></p>
-          </div>
-          <% else  %>
-            <h3>REDUCED</h3>
-            <p><%= eval(@version.photos[0])[:dimensions][0]/10 %> x <%= eval(@version.photos[0])[:dimensions][1]/10 %> px</p>
-          </div>
-            <div class="smaller">
-              <h3>SMALLER</h3>
-              <p><strong>90%</strong></p>
-            </div>
-          </div>
-          <div class="solutions" data-dark-mode-target="image">
-                  <h2><i class="fa-solid fa-lightbulb" data-dark-mode-target="bulb"></i> Use fewer pixels</h2>
-                  <%# <p>This image is  <strong><%= eval(@version.photos[0])[:dimensions][0] x <%= eval(@version.photos[0])[:dimensions][1] pixels</strong></p>%>
-                  <p>Are your image files larger than their container? Generally speaking, image pixel sizes should be no larger than their div container. For example, if your div is 500 x 400px but your image is 3000 x 2000 px, your user will never see the extra pixels, and your large file will increase your carbon footprint.</p>
-                  <p class="mb-0"><a href="">Learn More</a></p>
-          </div>
-        <% end %>
-        </div>
-      </div>
     </div>
-
-
-
 
     <div class="row analysis-row">
       <div class="tip-card ps-0 col-8">
@@ -290,6 +289,7 @@
         </div>
       </div>
     </div>
+  <% end %>
 
 
 
@@ -310,7 +310,7 @@
               <% if @version.font_families %>
                 <p><%= @version.font_families[0] %>, <%= @version.font_families[1] %>, <%= @version.font_families[2] %> </p>
               <% else %>
-                <p>The fonts could not be scraped 🙈</p>
+                <p>We couldn't find the fonts for your site 🙈</p>
               <% end %>
             </div>
             <div class="smaller">


### PR DESCRIPTION
Added fix to show page for extended images results. Changed explanatory text on show page and homepage. Removed extraneous social icons from footer. Changed sleep time back to 20 seconds for the time being, 10 seconds is too short for many pages to load fully.